### PR TITLE
New: support for using the hostname as the default environment name

### DIFF
--- a/src/bin/storyplayer
+++ b/src/bin/storyplayer
@@ -152,6 +152,14 @@ function main($argv)
 		'staticConfigManager'  => $staticConfigManager,
 	);
 
+	// special case - does the user want us to use his/her computer's
+	// hostname as the default environment name?
+	$defaultEnvName = null;
+	if (isset($staticConfig->preferences, $staticConfig->preferences->useHostnameAsDefaultEnvironment)
+		&& $staticConfig->preferences->useHostnameAsDefaultEnvironment) {
+		$defaultEnvName = getHostname();
+	}
+
 	// ====================================================================
 	//
 	// PARSE THE COMMAND-LINE
@@ -177,7 +185,7 @@ function main($argv)
 	$engine->addEngineSwitch(new ShortHelpSwitch);
 	$engine->addEngineSwitch(new VerboseShortSwitch($engine->options, 0, 3));
 	$engine->addEngineSwitch(new VerboseLongSwitch($engine->options, 0, 3));
-	$engine->addEngineSwitch(new EnvironmentSwitch($envList));
+	$engine->addEngineSwitch(new EnvironmentSwitch($envList, $defaultEnvName));
 
 	// what is our default command?
 	// this is normally some sort of help command

--- a/src/php/DataSift/Storyplayer/Cli/EnvironmentSwitch.php
+++ b/src/php/DataSift/Storyplayer/Cli/EnvironmentSwitch.php
@@ -60,10 +60,13 @@ use Phix_Project\CliEngine\CliResult;
  */
 class EnvironmentSwitch extends CliEngineSwitch
 {
-	public function __construct($envList)
+	public function __construct($envList, $defaultEnvName)
 	{
 		// remember the list of available environments
 		$this->envList = $envList;
+
+		// remember the user's prefered test environment (can be NULL)
+		$this->defaultEnvName = $defaultEnvName;
 	}
 
 	public function getDefinition()
@@ -80,6 +83,11 @@ class EnvironmentSwitch extends CliEngineSwitch
 		// what is the required argument?
 		$def->setRequiredArg('<environment>', "the environment to test against");
 		$def->setArgValidator(new EnvironmentValidator($this->envList));
+
+		// does the user have a preferred test environment?
+		if ($this->defaultEnvName) {
+			$def->setArgHasDefaultValueOf($this->defaultEnvName);
+		}
 
 		// all done
 		return $def;


### PR DESCRIPTION
New: you can now tell Storyplayer to use your computer's hostname as the default --environment

HOWTO:
add this to your $HOME/.storyplayer/storyplayer.json file:
{
    "preferences": {
        "useHostnameAsDefaultEnvironment": true
    }
}
