### PR TITLE
New: create-story command

### DIFF
--- a/src/bin/storyplayer
+++ b/src/bin/storyplayer
@@ -22,6 +22,7 @@ use Phix_Project\CliEngine\Switches\VerboseLongSwitch;
 use Phix_Project\CliEngine\Switches\VersionSwitch;
 use Phix_Project\CliEngine\Commands\HelpCommand;
 
+use DataSift\Storyplayer\Cli\CreateStoryCommand;
 use DataSift\Storyplayer\Cli\DefaultStaticConfig;
 use DataSift\Storyplayer\Cli\EnvironmentsListHelper;
 use DataSift\Storyplayer\Cli\InstallCommand;
@@ -258,6 +259,7 @@ function main($argv)
 	// note - if we add no additional commands, the default command is implied
 	//        and the user does not have to type it on the command line
 	$engine->addCommand(new HelpCommand);
+	$engine->addCommand(new CreateStoryCommand);
 	$engine->addCommand(new ListEnvironmentsCommand($envList));
 	$engine->addCommand(new InstallCommand);
 	$engine->addCommand(new ListHostsTableCommand);

--- a/src/php/DataSift/Storyplayer/Cli/BasedOnSwitch.php
+++ b/src/php/DataSift/Storyplayer/Cli/BasedOnSwitch.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * Copyright (c) 2011-present Mediasift Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the names of the copyright holders nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @category  Libraries
+ * @package   Storyplayer/Cli
+ * @author    Stuart Herbert <stuart.herbert@datasift.com>
+ * @copyright 2011-present Mediasift Ltd www.datasift.com
+ * @license   http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link      http://datasift.github.io/storyplayer
+ */
+
+namespace DataSift\Storyplayer\Cli;
+
+use Phix_Project\CliEngine;
+use Phix_Project\CliEngine\CliResult;
+use Phix_Project\CliEngine\CliSwitch;
+
+use DataSift\Storyplayer\ValidationLib\MustBeValidStoryTemplate;
+
+/**
+ * Set the story template that your new story is based on
+ *
+ * @category  Libraries
+ * @package   Storyplayer/Cli
+ * @author    Stuart Herbert <stuart.herbert@datasift.com>
+ * @copyright 2011-present Mediasift Ltd www.datasift.com
+ * @license   http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link      http://datasift.github.io/storyplayer
+ */
+class BasedOnSwitch extends CliSwitch
+{
+	public function __construct()
+	{
+		// define our name, and our description
+		$this->setName('basedOn');
+		$this->setShortDescription('base your new story on a StoryTemplate');
+
+		// what are the short switches?
+		$this->addShortSwitch('b');
+
+		// what are the long switches?
+		$this->addLongSwitch('based-on');
+
+		// what is the required argument?
+		$this->setRequiredArg('<classname>', "the StoryTemplate class to base your new story on");
+		$this->setArgValidator(new MustBeValidStoryTemplate);
+
+		// this argument is repeatable
+		$this->setSwitchIsRepeatable();
+
+		// all done
+	}
+
+	public function process(CliEngine $engine, $invokes = 1, $params = array(), $isDefaultParam = false)
+	{
+		// remember the setting
+		$engine->options->basedOn = $params;
+
+		// tell the engine that it is done
+		return new CliResult(CliResult::PROCESS_CONTINUE);
+	}
+}

--- a/src/php/DataSift/Storyplayer/Cli/CreateStoryCommand.php
+++ b/src/php/DataSift/Storyplayer/Cli/CreateStoryCommand.php
@@ -1,0 +1,272 @@
+<?php
+
+/**
+ * Copyright (c) 2011-present Mediasift Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the names of the copyright holders nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @category  Libraries
+ * @package   Storyplayer/Cli
+ * @author    Stuart Herbert <stuart.herbert@datasift.com>
+ * @copyright 2011-present Mediasift Ltd www.datasift.com
+ * @license   http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link      http://datasift.github.io/storyplayer
+ */
+
+namespace DataSift\Storyplayer\Cli;
+
+use Phix_Project\CliEngine;
+use Phix_Project\CliEngine\CliCommand;
+use Phix_Project\CliEngine\CliEngineSwitch;
+use Phix_Project\CliEngine\CliResult;
+use Phix_Project\ExceptionsLib1\Legacy_ErrorHandler;
+
+/**
+ * A command to create a new story to fill in
+ *
+ * @category  Libraries
+ * @package   Storyplayer/Cli
+ * @author    Stuart Herbert <stuart.herbert@datasift.com>
+ * @copyright 2011-present Mediasift Ltd www.datasift.com
+ * @license   http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link      http://datasift.github.io/storyplayer
+ */
+class CreateStoryCommand extends CliCommand
+{
+    public function __construct()
+    {
+        // define the command
+        $this->setName('create-story');
+        $this->setShortDescription('create a new story');
+        $this->setLongDescription(
+            "Use this command to create a new Story.php file, complete with "
+            ."the necessary PHP 'use' statement and comments to help guide you "
+            ."as you bring your story to life."
+            .PHP_EOL
+        );
+        $this->setArgsList(array(
+            "[<story.php|list.json>]" => "the story.php file to create"
+        ));
+        $this->setSwitches(array(
+            new BasedOnSwitch,
+            new ForceSwitch
+        ));
+    }
+
+    public function processCommand(CliEngine $engine, $params = array(), $additionalContext = null)
+    {
+        // do we have the name of the file to create?
+        if (!isset($params[0])) {
+            echo "*** error: you must specify which story to create\n";
+            exit(1);
+        }
+
+        // we're going to be dealing with some prehistoric parts of PHP
+        $legacyHandler = new Legacy_ErrorHandler();
+
+        // create the path to the story
+        $storyFolder = dirname($params[0]);
+        if (!file_exists($storyFolder)) {
+            try {
+                $legacyHandler->run(function() use ($storyFolder) {
+                    mkdir($storyFolder, 0755, true);
+                });
+            }
+            catch (Exception $e) {
+                echo "*** error: unable to create folder '{$storyFolder}'\n";
+                exit(1);
+            }
+        }
+
+        // create the story inside the folder
+        $story = <<<EOS
+<?php
+
+use DataSift\Storyplayer\PlayerLib\StoryTeller;
+
+EOS;
+
+        if (isset($engine->options->basedOn)) {
+            foreach ($engine->options->basedOn as $templateClass) {
+                $story .= "use {$templateClass};\n";
+            }
+        }
+        $story .= <<<EOS
+
+// ========================================================================
+//
+// STORY DETAILS
+//
+// ------------------------------------------------------------------------
+
+\$story = newStoryFor('Top-Level Category')
+         ->inGroup('Group inside Top-level Category')
+         ->called('Your story name')
+EOS;
+
+        if (isset($engine->options->basedOn)) {
+            $i = 0;
+            foreach ($engine->options->basedOn as $templateClass) {
+                if ($i == 0) {
+                    $story .= "\n         ->basedOn(new " . basename(str_replace('\\', '/', $templateClass)) . ")";
+                }
+                else {
+                    $story .= "\n         ->andBasedOn(new " . basename(str_replace('\\', '/', $templateClass)) . ")";
+                }
+                $i++;
+            }
+        }
+
+        $story .= ";";
+        $story .= <<<EOS
+
+
+// ========================================================================
+//
+// TEST ENVIRONMENT SETUP / TEAR-DOWN
+//
+// ------------------------------------------------------------------------
+
+/*
+\$story->addTestEnvironmentSetup(function(StoryTeller \$st) {
+    // create any test environment (e.g. start a virtual machine)
+    // that this story requires
+    //
+    // test environments are normally the same for several stories;
+    // so you might prefer to add them to a StoryTemplate instead
+});
+*/
+
+/*
+\$story->addTestEnvironmentTeardown(function(StoryTeller \$st) {
+    // undo anything that you did in addTestEnvironmentSetup()
+});
+*/
+
+// ========================================================================
+//
+// TEST SETUP / TEAR-DOWN
+//
+// ------------------------------------------------------------------------
+
+/*
+\$story->addTestSetup(function(StoryTeller \$st) {
+    // setup the conditions for this specific test
+});
+*/
+
+/*
+\$story->addTestTeardown(function(StoryTeller \$st) {
+    // undo anything that you did in addTestSetup()
+});
+*/
+
+// ========================================================================
+//
+// PRE-TEST PREDICTION
+//
+// ------------------------------------------------------------------------
+
+/*
+\$story->addPreTestPrediction(function(StoryTeller \$st) {
+    // if it is okay for your story to fail, detect that here
+});
+*/
+
+// ========================================================================
+//
+// PRE-TEST INSPECTION
+//
+// ------------------------------------------------------------------------
+
+/*
+\$story->addPreTestInspection(function(StoryTeller \$st) {
+    // get the checkpoint - we're going to store data in here
+    \$checkpoint = \$st->getCheckpoint();
+
+    // store any data that your story is about to change, so that you
+    // can do a before and after comparison
+});
+*/
+
+// ========================================================================
+//
+// POSSIBLE ACTION(S)
+//
+// ------------------------------------------------------------------------
+
+/*
+\$story->addAction(function(StoryTeller \$st) {
+    // this is where you perform the steps of your user story
+});
+*/
+
+// ========================================================================
+//
+// POST-TEST INSPECTION
+//
+// ------------------------------------------------------------------------
+
+\$story->addPostTestInspection(function(StoryTeller \$st) {
+    // the information to guide our checks is in the checkpoint
+    \$checkpoint = \$st->getCheckpoint();
+
+    // gather new data, and make sure that your action actually changed
+    // something. never assume that the action worked just because it
+    // completed to the end with no errors or exceptions!
+});
+
+EOS;
+
+        // does the file already exist?
+        if (file_exists($params[0])) {
+            // has the user used --force?
+            if (!isset($engine->options->force) || !$engine->options->force) {
+                echo "*** error: file '{$params[0]}' already exists\n";
+                echo "use --force to replace this file with the new story file\n";
+                exit(1);
+            }
+        }
+
+        try {
+            $legacyHandler->run(function() use($params, $story) {
+                file_put_contents($params[0], $story);
+            });
+        }
+        catch (Exception $e) {
+            echo "*** error: " . $e->getMessage() . "\n";
+            exit(1);
+        }
+
+        // all done
+        return new CliResult(0);
+    }
+}

--- a/src/php/DataSift/Storyplayer/Cli/ForceSwitch.php
+++ b/src/php/DataSift/Storyplayer/Cli/ForceSwitch.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * Copyright (c) 2011-present Mediasift Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the names of the copyright holders nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @category  Libraries
+ * @package   Storyplayer/Cli
+ * @author    Stuart Herbert <stuart.herbert@datasift.com>
+ * @copyright 2011-present Mediasift Ltd www.datasift.com
+ * @license   http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link      http://datasift.github.io/storyplayer
+ */
+
+namespace DataSift\Storyplayer\Cli;
+
+use Phix_Project\CliEngine;
+use Phix_Project\CliEngine\CliResult;
+use Phix_Project\CliEngine\CliSwitch;
+
+/**
+ * Tell Storyplayer to force something to happen
+ *
+ * @category  Libraries
+ * @package   Storyplayer/Cli
+ * @author    Stuart Herbert <stuart.herbert@datasift.com>
+ * @copyright 2011-present Mediasift Ltd www.datasift.com
+ * @license   http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link      http://datasift.github.io/storyplayer
+ */
+class ForceSwitch extends CliSwitch
+{
+	public function __construct()
+	{
+		// define our name, and our description
+		$this->setName('force');
+		$this->setShortDescription('force the action to happen');
+
+		// what are the short switches?
+		$this->addShortSwitch('f');
+
+		// what are the long switches?
+		$this->addLongSwitch('force');
+
+		// all done
+	}
+
+	public function process(CliEngine $engine, $invokes = 1, $params = array(), $isDefaultParam = false)
+	{
+		// remember the setting
+		$engine->options->force = true;
+
+		// tell the engine that it is done
+		return new CliResult(CliResult::PROCESS_CONTINUE);
+	}
+}

--- a/src/php/DataSift/Storyplayer/ValidationLib/MustBeValidStoryTemplate.php
+++ b/src/php/DataSift/Storyplayer/ValidationLib/MustBeValidStoryTemplate.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * Copyright (c) 2011-present Mediasift Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the names of the copyright holders nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @category  Libraries
+ * @package   Storyplayer/ValidationLib
+ * @author    Stuart Herbert <stuart.herbert@datasift.com>
+ * @copyright 2011-present Mediasift Ltd www.datasift.com
+ * @license   http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link      http://datasift.github.io/storyplayer
+ */
+
+namespace DataSift\Storyplayer\ValidationLib;
+
+use ReflectionClass;
+
+use Phix_Project\ValidationLib4\Validator;
+use Phix_Project\ValidationLib4\ValidationResult;
+
+/**
+ * Set the story template that your new story is based on
+ *
+ * @category  Libraries
+ * @package   Storyplayer/Cli
+ * @author    Stuart Herbert <stuart.herbert@datasift.com>
+ * @copyright 2011-present Mediasift Ltd www.datasift.com
+ * @license   http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link      http://datasift.github.io/storyplayer
+ */
+class MustBeValidStoryTemplate implements Validator
+{
+    const MSG_NOTVALIDCLASS = "'%value%' is not a valid PHP class";
+    const MSG_NOTVALIDTEMPLATE = "'%value%' is a PHP class, but it does not extend DataSift\Storyplayer\PlayerLib\StoryTemplate";
+
+    public function validate($value, ValidationResult $result = null)
+    {
+        if ($result === null)
+        {
+            $result = new ValidationResult($value);
+        }
+
+        // we need a valid PHP class
+        if (!class_exists($value))
+        {
+        	$result->addError(static::MSG_NOTVALIDCLASS);
+        	return $result;
+        }
+
+        // the class must be a StoryTemplate
+        $refClass = new ReflectionClass($value);
+        if (!$refClass->isSubclassOf('DataSift\Storyplayer\PlayerLib\StoryTemplate'))
+        {
+        	$result->addError(static::MSG_NOTVALIDTEMPLATE);
+        	return $result;
+        }
+
+        // all done
+        return $result;
+    }
+}


### PR DESCRIPTION
This PR adds a new 'create-story' command, which creates a Story.php file full of helpful comments to guide you through writing a new test.

```
storyplayer create-story <path-to-story.php>
```

You can use the --based-on switch to tell the story which StoryTemplate(s) to base the story on:

```
storyplayer create-story --based-on DataSift\QA\StoryTemplates\PickleTemplate <path-to-story.php>
```

By default, you can't overwrite an existing file, but the --force switch is available for those who know what they are doing.
