### PR TITLE
Fixes finding elements if they have a negative location (e.g. 

### DIFF
--- a/src/php/DataSift/Storyplayer/Prose/BrowserDetermine.php
+++ b/src/php/DataSift/Storyplayer/Prose/BrowserDetermine.php
@@ -93,7 +93,7 @@ class BrowserDetermine extends Prose
 			}
 
 			$location = $element->location();
-			if ($location['x'] >=0 && $location['y'] >= 0) {
+			if ($location['x'] <> 0 && $location['y'] <> 0) {
 				$log->endAction($successMsg);
 
 				// return the element


### PR DESCRIPTION
An example of this is if the element is still _displayed_ on the page but not visible on the screen, for example due to browser dimensions during the story playing.

If an element has position x=0,y=0, this check will still fail of course.
