### PR TITLE
Fix: drop onscreen/offscreen location check

### DIFF
--- a/src/php/DataSift/Storyplayer/Prose/BrowserDetermine.php
+++ b/src/php/DataSift/Storyplayer/Prose/BrowserDetermine.php
@@ -92,13 +92,11 @@ class BrowserDetermine extends Prose
 				continue;
 			}
 
-			$location = $element->location();
-			if ($location['x'] >=0 && $location['y'] >= 0) {
-				$log->endAction($successMsg);
+			// we have our element :)
+			$log->endAction($successMsg);
 
-				// return the element
-				return $element;
-			}
+			// return the element
+			return $element;
 		}
 
 		// if we get here, then there was no visible element


### PR DESCRIPTION
When finding a DOM element in the browser, we used to check to make sure it was onscreen before returning it, to avoid exceptions from Selenium when trying to interact with the element.  This is reported to be no longer required, so we're dropping it for now.
