### PR TITLE
Fix: When a command returns multiple lines, pass them all through as the...

### DIFF
--- a/src/php/DataSift/Storyplayer/Prose/UsingShell.php
+++ b/src/php/DataSift/Storyplayer/Prose/UsingShell.php
@@ -69,7 +69,9 @@ class UsingShell extends Prose
 
 		// run the command
 		$returnCode = null;
-		$output = system($command, $returnCode);
+		$lines = array();
+		exec($command, $lines, $returnCode);
+		$output = implode(PHP_EOL, $lines);
 
 		// all done
 		$log->endAction("return code was '{$returnCode}'; output was '{$output}'");


### PR DESCRIPTION
... return value.

Simple reproduction case for this is to run `ls` in a folder with more than one file. Previously, only the last item was returned.
