### PR TITLE
New: support for restricting environments that stories can run against

### DIFF
--- a/src/php/DataSift/Storyplayer/PlayerLib/StoryResult.php
+++ b/src/php/DataSift/Storyplayer/PlayerLib/StoryResult.php
@@ -62,6 +62,7 @@ class StoryResult
 	public $story = null;
 	public $phases = array();
 	public $storyResult = NULL;
+	public $storyAttempted = false;
 
 	public function __construct(Story $story)
 	{

--- a/src/php/DataSift/Storyplayer/StoryLib/Story.php
+++ b/src/php/DataSift/Storyplayer/StoryLib/Story.php
@@ -218,6 +218,19 @@ class Story
 	 */
 	protected $params = array();
 
+	/**
+	 * the environments that a story states it runs on
+	 *
+	 * by default, a story is allowed to run on all environments, *but*
+	 * if an environment's config sets 'mustBeWhitelisted' to TRUE, then
+	 * the story is only allowed to run on that environment if the story
+	 * declares itself safe to run
+	 *
+	 * we believe that this is the safest approach to handling those
+	 * stories that simply aren't safe to run absolutely everywhere
+	 */
+	protected $whitelistedEnvironments = array();
+
 	// ====================================================================
 	//
 	// Metadata about the story itself
@@ -582,6 +595,29 @@ class Story
 	public function getStoryTemplates()
 	{
 		return $this->storyTemplates;
+	}
+
+	// ====================================================================
+	//
+	// Information about environments
+	//
+	// --------------------------------------------------------------------
+
+	public function runsOn($envName)
+	{
+		$this->whitelistedEnvironments[$envName] = true;
+		return $this;
+	}
+
+	public function andOn($envName)
+	{
+		$this->whitelistedEnvironments[$envName] = true;
+		return $this;
+	}
+
+	public function getWhitelistedEnvironments()
+	{
+		return $this->whitelistedEnvironments;
 	}
 
 	// ====================================================================


### PR DESCRIPTION
This PR adds an important safety feature - the ability to restrict which environments a story can run against.  (Issue #64)
- The default behaviour is that all stories can run against all environments.  This preserves backwards compatibility, and makes it quick and easy to get into using Storyplayer in the first case.
- If an environment's config sets 'mustBeWhitelisted' to TRUE, then a story must call $story->runsOn(), otherwise the story will not be allowed to run.

This allows us to mark our production environment as an 'opt-in' environment; so that we can stop tests that do things like deleting all users running against that environment :)
