### PR TITLE
Send string request bodies in UsingHttp.

### DIFF
--- a/src/php/DataSift/Storyplayer/Prose/UsingHttp.php
+++ b/src/php/DataSift/Storyplayer/Prose/UsingHttp.php
@@ -119,6 +119,8 @@ class UsingHttp extends Prose
 			throw new E5xx_ActionFailed(__METHOD__);
 		}
 
+		$log->endAction();
+
 		// all done
 		return $response;
 	}


### PR DESCRIPTION
This fixes the issue I raised ([#81](https://github.com/datasift/storyplayer/issues/81)) where string request bodies were not being sent by UsingHttp.
