### PR TITLE
Fix custom prose namespacing to fit with documentation

### DIFF
--- a/src/php/DataSift/Storyplayer/PlayerLib/E5xx/InvalidConfig.php
+++ b/src/php/DataSift/Storyplayer/PlayerLib/E5xx/InvalidConfig.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * Copyright (c) 2011-present Mediasift Ltd
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the names of the copyright holders nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @category  Libraries
+ * @package   Storyplayer/PlayerLib
+ * @author    Stuart Herbert <stuart.herbert@datasift.com>
+ * @copyright 2011-present Mediasift Ltd www.datasift.com
+ * @license   http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link      http://datasift.github.io/storyplayer
+ */
+
+namespace DataSift\Storyplayer\PlayerLib;
+
+use DataSift\Stone\ExceptionsLib\Exxx_Exception;
+
+/**
+ * Exception thrown when we get invalid json config
+ *
+ * @category    Libraries
+ * @package     Storyplayer/PlayerLib
+ * @author      Stuart Herbert <stuart.herbert@datasift.com>
+ * @copyright   2011-present Mediasift Ltd www.datasift.com
+ * @license     http://www.opensource.org/licenses/bsd-license.php  BSD License
+ * @link        http://datasift.github.io/storyplayer
+ */
+class E5xx_InvalidConfig extends Exxx_Exception
+{
+	public function __construct($err) {
+		$msg = "Invalid config - $err";
+		parent::__construct(500, $msg, $msg);
+	}
+}
+

--- a/src/php/DataSift/Storyplayer/PlayerLib/StoryContext.php
+++ b/src/php/DataSift/Storyplayer/PlayerLib/StoryContext.php
@@ -160,9 +160,9 @@ class StoryContext extends BaseObject
 		$this->prose = array();
 
 		// where are we looking?
-		if (isset($staticConfig->prose)) {
-			if (!is_array($staticConfig->prose)) {
-				throw new E5xx_InvalidConfig("the 'prose' section of the config must either be an array, or it must be left out");
+		if (isset($staticConfig->prose, $staticConfig->prose->namespaces)) {
+			if (!is_array($staticConfig->prose->namespaces)) {
+				throw new E5xx_InvalidConfig("the 'prose.namespaces' section of the config must either be an array, or it must be left out");
 			}
 
 			// copy over where to look for Prose classes


### PR DESCRIPTION
I was trying to use the custom prose namespace feature and was getting class not found error for a thrown exception, additionally the error seems to not match the documentation here http://datasift.github.io/storyplayer/configuration/prose-namespaces.html. 

This adds the missing exception and fixes the config check so that it checks that prose->namespaces is an array not prose.

Wasn't too sure with the exception the naming style used, InvalidConfig seems to be a lot more generic than the other exceptions, I kept it as was for now but can change to something more specific if needed.
