### PR TITLE
Merge in the environment saucelabs config into the browseDetails 

### DIFF
--- a/src/php/DataSift/Storyplayer/DeviceLib/SauceLabsWebDriverAdapter.php
+++ b/src/php/DataSift/Storyplayer/DeviceLib/SauceLabsWebDriverAdapter.php
@@ -66,6 +66,11 @@ class SauceLabsWebDriverAdapter extends BaseAdapter implements DeviceAdapter
 		// Sauce Labs handles proxying for us (if required)
 		// via the Sauce Connect app
 
+		// Merge the default saucelabs config into browseDetails
+		if (!isset($this->browserDetails->saucelabs)) {
+			$this->browserDetails->saucelabs = $st->getEnvironment()->saucelabs;
+		}
+
 		// build the Sauce Labs url
 		$url = "http://"
 		     . urlencode($this->browserDetails->saucelabs->username)


### PR DESCRIPTION
Fix for issue #85 this allows users to define saucelabs config as per the docs and also means they can have custom configs per device if needed.
