### PR TITLE
New: ported --persist-device from Storyplayer v1

### DIFF
--- a/src/php/DataSift/Storyplayer/Cli/PlayStory/PersistDeviceSwitch.php
+++ b/src/php/DataSift/Storyplayer/Cli/PlayStory/PersistDeviceSwitch.php
@@ -61,7 +61,7 @@ use Phix_Project\ValidationLib4\Type_MustBeString;
  * @license   http://www.opensource.org/licenses/bsd-license.php  BSD License
  * @link      http://datasift.github.io/storyplayer
  */
-class PersistDeviceSwitch extends CliSwitch
+class PlayStory_PersistDeviceSwitch extends CliSwitch
 {
 	public function __construct()
 	{

--- a/src/php/DataSift/Storyplayer/Phases/Phase.php
+++ b/src/php/DataSift/Storyplayer/Phases/Phase.php
@@ -161,7 +161,9 @@ abstract class Phase
 		}
 
 		// stop the test device, if it is still running
-		$st->stopDevice();
+		if (!$st->getPersistDevice()) {
+			$st->stopDevice();
+		}
 
 		// all done
 	}

--- a/src/php/DataSift/Storyplayer/PlayerLib/Phases/Player.php
+++ b/src/php/DataSift/Storyplayer/PlayerLib/Phases/Player.php
@@ -284,7 +284,9 @@ class Phases_Player
 		$st->closeAllOpenActions();
 
 		// stop any running test devices
-		$st->stopDevice();
+		if (!$st->getPersistDevice()) {
+			$st->stopDevice();
+		}
 
 		// close off any log actions left open by closing down
 		// the test device

--- a/src/php/DataSift/Storyplayer/PlayerLib/Story/Player.php
+++ b/src/php/DataSift/Storyplayer/PlayerLib/Story/Player.php
@@ -107,6 +107,12 @@ class Story_Player
         $story = Story_Loader::loadStory($this->storyFilename);
         $st->setStory($story);
 
+        // does our story want to keep the test device open between
+        // phases?
+        if ($story->getPersistDevice()) {
+        	$st->setPersistDevice();
+        }
+
         // initialise the user
         $context = $st->getStoryContext();
         $context->initUser($st);

--- a/src/php/DataSift/Storyplayer/PlayerLib/StoryTeller.php
+++ b/src/php/DataSift/Storyplayer/PlayerLib/StoryTeller.php
@@ -195,6 +195,7 @@ class StoryTeller
 	private $device = null;
 	private $deviceName = null;
 	private $deviceAdapter = null;
+	private $persistDevice = false;
 
 	// the config that Storyplayer is running with
 	private $config = null;
@@ -677,6 +678,16 @@ class StoryTeller
 	// Device support
 	//
 	// ------------------------------------------------------------------
+
+	public function getPersistDevice()
+	{
+		return $this->persistDevice;
+	}
+
+	public function setPersistDevice()
+	{
+		$this->persistDevice = true;
+	}
 
 	public function getDeviceDetails()
 	{

--- a/src/php/DataSift/Storyplayer/StoryLib/Story.php
+++ b/src/php/DataSift/Storyplayer/StoryLib/Story.php
@@ -262,6 +262,13 @@ class Story
 	 */
 	protected $requiredTestEnvRoles = array();
 
+	/**
+	 * does the story want the test device kept open between phases?
+	 *
+	 * @var boolean
+	 */
+	protected $persistDevice = false;
+
 	// ====================================================================
 	//
 	// Metadata about the story itself
@@ -670,6 +677,34 @@ class Story
 	public function getRequiredTestEnvironmentRoles()
 	{
 		return $this->requiredTestEnvRoles;
+	}
+
+	// ==================================================================
+	//
+	// Device support
+	//
+	// ------------------------------------------------------------------
+
+	/**
+	 * does this story want to keep the web browser open between phases?
+	 *
+	 * @return boolean
+	 */
+	public function getPersistDevice()
+	{
+		return $this->persistDevice;
+	}
+
+	/**
+	 * tell Storyplayer to keep the web browser open between test phases
+	 *
+	 * by default, we close the browser after every phase, to make sure
+	 * that the next phase always starts with a browser in a known state
+	 */
+	public function setPersistDevice()
+	{
+		$this->persistDevice = true;
+		return $this;
 	}
 
 	// ====================================================================

--- a/src/tests/stories/web-browser/CanPersistTestDeviceStory.php
+++ b/src/tests/stories/web-browser/CanPersistTestDeviceStory.php
@@ -1,0 +1,66 @@
+<?php
+
+use DataSift\Storyplayer\PlayerLib\StoryTeller;
+
+// ========================================================================
+//
+// STORY DETAILS
+//
+// ------------------------------------------------------------------------
+
+$story = newStoryFor('Storyplayer Service Stories')
+         ->inGroup('Web Browsing')
+         ->called('Can persist the test device');
+
+// keep the test device open
+//$story->setPersistDevice();
+
+// ========================================================================
+//
+// TEST ENVIRONMENT SETUP / TEAR-DOWN
+//
+// ------------------------------------------------------------------------
+
+// ========================================================================
+//
+// STORY SETUP / TEAR-DOWN
+//
+// ------------------------------------------------------------------------
+
+// ========================================================================
+//
+// PRE-TEST PREDICTION
+//
+// ------------------------------------------------------------------------
+
+// ========================================================================
+//
+// PRE-TEST INSPECTION
+//
+// ------------------------------------------------------------------------
+
+// ========================================================================
+//
+// POSSIBLE ACTION(S)
+//
+// ------------------------------------------------------------------------
+
+$story->addAction(function(StoryTeller $st) {
+    // load our test page
+    $st->usingBrowser()->gotoPage("file://" . __DIR__ . '/../testpages/index.html');
+});
+
+// ========================================================================
+//
+// POST-TEST INSPECTION
+//
+// ------------------------------------------------------------------------
+
+$story->setPostTestInspection(function(StoryTeller $st) {
+	// if this feature is working, the browser should already be open
+	// and we can just grab the title
+	$title = $st->fromBrowser()->getTitle();
+
+	// do we have the title we expected?
+	$st->assertsString($title)->equals("Storyplayer: Welcome To The Tests!");
+});


### PR DESCRIPTION
By default, Storyplayer closes any open test device between phases. You can now override this behaviour if you wish to.
- --persist-device switch
- $story->setPersistDevice()
