### PR TITLE
New: warn when stories do not end in Story.php

### DIFF
--- a/src/php/DataSift/Storyplayer/Cli/PlayStory/Command.php
+++ b/src/php/DataSift/Storyplayer/Cli/PlayStory/Command.php
@@ -419,6 +419,15 @@ class PlayStory_Command extends CliCommand
 
     protected function addStoryFromFile(CliEngine $engine, Injectables $injectables, $storyFile)
     {
+        // warn the user if the story file doesn't end in 'Story.php'
+        //
+        // this is because Storyplayer will ignore the file if you
+        // point Storyplayer at a folder instead of a specific file
+        if (substr($storyFile, -9) != 'Story.php') {
+            $msg = "your story should end in 'Story.php', but it does not" . PHP_EOL;
+            $this->output->logCliWarning($msg);
+        }
+
         // these are the players we want to execute for the story
         $return = [
             new TestEnvironment_Player([


### PR DESCRIPTION
If your story file does not end in 'Story.php', we now output a warning to the output mechanisms.

Why do we need this warning?  
- The command `storyplayer <folder>` will only play files that end in 'Story.php'.
- I've noticed that it's very easy for people to forget / not realise that their stories should end in 'Story.php'
