### PR TITLE
Fix: -D switch works again

### DIFF
--- a/src/php/DataSift/Storyplayer/Cli/Common/DefineSwitch.php
+++ b/src/php/DataSift/Storyplayer/Cli/Common/DefineSwitch.php
@@ -94,14 +94,36 @@ class Common_DefineSwitch extends CliSwitch
 			$engine->options->defines = new stdClass;
 		}
 
-		foreach ($params as $param) {
+		foreach ($params as $param)
+		{
 			// split up the setting
 			$parts = explode('=', $param);
 			$key   = array_shift($parts);
 			$value = implode('=', $parts);
 
-			// remember the setting
-			$engine->options->defines->$key = $value;
+			// do we want to convert the type of $value?
+			$lowerValue = strtolower($value);
+			if ($lowerValue == 'false') {
+				$value = false;
+			}
+			else if ($lowerValue == 'true') {
+				$value = true;
+			}
+			else if ($lowerValue == 'null') {
+				$value = null;
+			}
+
+			// expand dot notation
+			$parts = explode('.', $key);
+			$currentLevel = $engine->options->defines;
+			$lastPart = array_pop($parts);
+
+			foreach ($parts as $part) {
+				$currentLevel->$part = new stdClass;
+				$currentLevel = $currentLevel->$part;
+			}
+			// store the value into the tree
+			$currentLevel->$lastPart = $value;
 		}
 
 		// tell the engine that it is done

--- a/src/php/DataSift/Storyplayer/Cli/Common/DefinesSupport.php
+++ b/src/php/DataSift/Storyplayer/Cli/Common/DefinesSupport.php
@@ -85,7 +85,7 @@ class Common_DefinesSupport implements Common_Functionality
         // this must be done AFTER all config files have been loaded!
         if (isset($engine->options->defines)) {
             // merge into the default + what was loaded from config files
-            $staticConfig->defines->mergeFrom($engine->options->defines);
+            $injectables->activeConfig->mergeFrom($engine->options->defines);
         }
     }
 }

--- a/src/php/DataSift/Storyplayer/Cli/DefaultCommonFunctionality.php
+++ b/src/php/DataSift/Storyplayer/Cli/DefaultCommonFunctionality.php
@@ -59,11 +59,11 @@ use Phix_Project\CliEngine\CliCommand;
 class DefaultCommonFunctionality
 {
 	public $classes = [
-		"Common_DefinesSupport"                => "Common_DefinesSupport",
 		"Common_DeviceSupport"                 => "Common_DeviceSupport",
 		"Common_TestEnvironmentConfigSupport"  => "Common_TestEnvironmentConfigSupport",
 		"Common_SystemUnderTestConfigSupport"  => "Common_SystemUnderTestConfigSupport",
 		"Common_ActiveConfigSupport"           => "Common_ActiveConfigSupport",
+		"Common_DefinesSupport"                => "Common_DefinesSupport",
 		"Common_ConsoleSupport"                => "Common_ConsoleSupport",
 		"Common_ColorSupport"                  => "Common_ColorSupport",
 		"Common_PhaseLoaderSupport"            => "Common_PhaseLoaderSupport",

--- a/src/php/DataSift/Storyplayer/Cli/DefaultConfig.php
+++ b/src/php/DataSift/Storyplayer/Cli/DefaultConfig.php
@@ -54,7 +54,13 @@ use DataSift\Stone\ObjectLib\BaseObject;
  * 3: we override config with command-line params
  *
  * The StaticConfigManager class is where you'll find all of the logic
- * for loading and merging data.
+ * for loading data.
+ *
+ * Injectables\ActiveConfigSupport is where you'll find all of the logic
+ * for merging data from config files.
+ *
+ * Cli\Common\DefinesSupport is where you'll find all of the logic for
+ * merging data from the command-line params (-D switch)
  *
  * ALL of the public properties on this object are data bags of one kind
  * or another.
@@ -69,8 +75,6 @@ use DataSift\Stone\ObjectLib\BaseObject;
 class DefaultConfig extends BaseObject
 {
     public $appSettings;
-    public $defines;
-    public $logger;
     public $phases;
     public $prose;
     public $reports;
@@ -125,9 +129,6 @@ class DefaultConfig extends BaseObject
         $phases->script->Automate = true;
 
         $this->phases = $phases;
-
-        // defaults for defines
-        $this->defines = new BaseObject();
     }
 
     public function checkPhases()

--- a/src/php/DataSift/Storyplayer/Cli/PlayStory/Command.php
+++ b/src/php/DataSift/Storyplayer/Cli/PlayStory/Command.php
@@ -285,6 +285,9 @@ class PlayStory_Command extends CliCommand
             $engine->getAppLicense()
         );
 
+        var_dump($injectables->activeConfig);
+        exit(0);
+
         // $this->playerList contains one or more things to play
         //
         // let's play each of them in order

--- a/src/php/DataSift/Storyplayer/PlayerLib/Story.php
+++ b/src/php/DataSift/Storyplayer/PlayerLib/Story.php
@@ -483,18 +483,14 @@ class Story
 	/**
 	 * Set the parameters for this story
 	 *
-	 * Parameters are simple settings for use throughout the execution
-	 * of the story.  They were originally added for injection into
-	 * virtual machine configurations, but have since evolved to be
-	 * arbitrary key/value settings used throughout the story, and to be
-	 * overridable from the command-line.
+	 * Parameters are a way of passing settings between Stories and
+	 * StoryTemplates.
 	 *
 	 * Order of precedence:
 	 *
-	 * 1) StoryTemplates (in 'basedOn()' order)
+	 * 1) Story
+	 * 2) StoryTemplates (in 'basedOn()' order)
 	 *    (templates cannot override each other)
-	 * 2) Story
-	 * 3) -D on the command-line
 	 *
 	 * @param array $defaults
 	 *        a list of the parameters for this story
@@ -518,11 +514,7 @@ class Story
 			// any params already set have precedence
 			foreach ($params as $key => $value) {
 				// do we have a clash?
-				if (isset($return[$key])) {
-					// TODO: address when we revisit -D support
-					Log::write(Log::LOG_WARNING, "StoryTemplate '" . get_class($template) . "' attempting to set duplicate story parameter '{$key}'; using existing value '{$return['$key']}' instead of template value '{$value}'");
-				}
-				else {
+				if (!isset($return[$key])) {
 					$return[$key] = $value;
 				}
 			}

--- a/src/php/DataSift/Storyplayer/PlayerLib/StoryTeller.php
+++ b/src/php/DataSift/Storyplayer/PlayerLib/StoryTeller.php
@@ -592,44 +592,26 @@ class StoryTeller
 		return $this->storyContext->user;
 	}
 
-	/**
-	 *
-	 * @return array
-	 */
-	public function getDefines()
-	{
-		return $this->defines;
-	}
-
-	/**
-	 *
-	 * @param array $defines
-	 */
-	public function setDefines($defines)
-	{
-		$this->defines = $defines;
-	}
+	// ==================================================================
+	//
+	// Per-story parameter support
+	//
+	// ------------------------------------------------------------------
 
 	public function getParams()
 	{
 		// get the current parameters from the story
 		//
-		// these may have been previously augmented by a template
-		// calling $st->addDefaultParams()
-		$return = $this->getStory()->getParams();
-
-		// merge in any defines from the command-line
-		$defines = $this->getDefines();
-		foreach ($defines as $key => $value) {
-			$return[$key] = $value;
-		}
-
-		// all done
-		//
 		// NOTE that we deliberately don't cache $return in here, as
 		// the parameters storied in the story can (in theory) change
 		// at any moment
-		return $return;
+		//
+		// NOTE that these are (deliberately) completely independent
+		// from anything set using -D on the command-line
+		//
+		// parameters are now simply a way for stories to pass settings
+		// into StoryTemplates that they are based upon, nothing more
+		return $this->getStory()->getParams();
 	}
 
 	// ==================================================================


### PR DESCRIPTION
This PR makes the -D switch work once more.
- -D sets values in the main config
- dot notation is finally supported for -D
- -D no longer affects story/storytemplate params at all
