### PR TITLE
DEV-1490 fix IP address detection issue

### DIFF
--- a/src/php/DataSift/Storyplayer/OsLib/Base/Centos5.php
+++ b/src/php/DataSift/Storyplayer/OsLib/Base/Centos5.php
@@ -74,7 +74,7 @@ abstract class Base_Centos5 extends Base_Unix
 		$log = $st->startAction("query " . basename(__CLASS__) . " for IP address");
 
 		if (empty($hostDetails->ifaces)) {
-			// set defaul tnetwork interfaces
+			// set default network interfaces
 			$hostDetails->ifaces = array('eth1', 'eth0');
 		}
 

--- a/src/php/DataSift/Storyplayer/OsLib/Base/Centos5.php
+++ b/src/php/DataSift/Storyplayer/OsLib/Base/Centos5.php
@@ -75,7 +75,7 @@ abstract class Base_Centos5 extends Base_Unix
 
 		if (empty($hostDetails->ifaces)) {
 			// set defaul tnetwork interfaces
-			$hostDetails->ifaces = array('docker0', 'eth1', 'eth0');
+			$hostDetails->ifaces = array('eth1', 'eth0');
 		}
 
 		// how do we do this?


### PR DESCRIPTION
This change fixes two issues related to the detaction of IP address on the virtual machine:

The first issue is that the $result->didCommandSucceed() returns the exit code 0 even if the interface is not found and the second network interface is never processed. To fix that I have added a check on the returned string.

The second issue is related to the fact that we may have machines with different network interfaces and we want to pick just one or try them in a different order. To fix this I have added the ability to specify an array of interfaces to test in the test-environments configuration file via the "ifaces" field. For example:

[
	{
		"type": "LocalVagrantVms",
		"functions": [
			"functional"
		],
		"details": {
			"machines": {
				"test-vm": {
					"osName": "centos6",
					"ifaces": [
						"eth0",
						"eth1"
					],
					"roles": [
						"test"
					],
					"appSettings": {
					}
				}
			}
		},
		"provisioning": {
			"engine": "dsbuild"
		}
	}
]

