### PR TITLE
DEV-1492 detect the correct VM instead of "default"

### DIFF
--- a/src/php/DataSift/Storyplayer/HostLib/VagrantVm.php
+++ b/src/php/DataSift/Storyplayer/HostLib/VagrantVm.php
@@ -403,7 +403,7 @@ class VagrantVm implements SupportedHost
 		$log = $st->startAction("determine status of Vagrant VM '{$vmDetails->hostId}'");
 
 		// if the box is running, it should have a status of 'running'
-		$command = "vagrant status | grep default | head -n 1 | awk '{print \$2'}";
+		$command = "vagrant status | grep {$vmDetails->hostId} | head -n 1 | awk '{print \$2'}";
 		$result  = $this->runCommandAgainstHostManager($vmDetails, $command);
 
 		$lines = explode("\n", $result->output);


### PR DESCRIPTION
The old code was checking for the "default" machine, so it was failing returning the correct status in case the VM had a different name.