### PR TITLE
fix mockery dependency bug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
 	},
 	"require-dev": {
 		"stuart/phingtasks": "1.0.0",
-		"mockery/mockery": "dev-master",
+		"mockery/mockery": "0.9.*",
 		"phpunit/phpunit": "~4.4"
 	},
 	"autoload": {


### PR DESCRIPTION
This fix the following bug triggered when running "composer install":
```
datasift/stone 1.9.15 requires mockery/mockery 0.9.* -> no matching package found.
```