### PR TITLE
Fix "Nesting level too deep - recursive dependency?" error

### DIFF
--- a/src/php/DataSift/Storyplayer/PlayerLib/StoryTeller.php
+++ b/src/php/DataSift/Storyplayer/PlayerLib/StoryTeller.php
@@ -359,7 +359,7 @@ class StoryTeller
     public function setStory(Story $story)
     {
         // are we already tracking this story?
-        if ($this->story == $story) {
+        if ($this->story === $story) {
             return $this;
         }
 


### PR DESCRIPTION
Fixes an error when running a group of tests.

PHP Fatal error:  Nesting level too deep - recursive dependency? in /Users/agnieszka/qa-stories-v2/vendor/datasift/storyplayer/src/php/DataSift/Storyplayer/PlayerLib/StoryTeller.php on line 364
PHP Stack trace:
PHP   1. {main}() /Users/agnieszka/qa-stories-v2/vendor/datasift/storyplayer/src/bin/storyplayer:0
PHP   2. main() /Users/agnieszka/qa-stories-v2/vendor/datasift/storyplayer/src/bin/storyplayer:355
PHP   3. Phix_Project\CliEngine->main() /Users/agnieszka/qa-stories-v2/vendor/datasift/storyplayer/src/bin/storyplayer:343
PHP   4. DataSift\Storyplayer\Cli\PlayStory_Command->processCommand() /Users/agnieszka/qa-stories-v2/vendor/phix/cliengine/src/php/Phix_Project/CliEngine.php:270
PHP   5. Phix_Project\ExceptionsLib1\Legacy_ErrorHandler->run() /Users/agnieszka/qa-stories-v2/vendor/datasift/storyplayer/src/php/DataSift/Storyplayer/Cli/PlayStory/Command.php:163
PHP   6. call_user_func_array:{/Users/agnieszka/qa-stories-v2/vendor/phix/exceptionslib/src/php/Phix_Project/ExceptionsLib1/Legacy/ErrorHandler.php:62}() /Users/agnieszka/qa-stories-v2/vendor/phix/exceptionslib/src/php/Phix_Project/ExceptionsLib1/Legacy/ErrorHandler.php:62
PHP   7. DataSift\Storyplayer\Cli\PlayStory_Command->processInsideLegacyHandler() /Users/agnieszka/qa-stories-v2/vendor/phix/exceptionslib/src/php/Phix_Project/ExceptionsLib1/Legacy/ErrorHandler.php:62
PHP   8. DataSift\Storyplayer\PlayerLib\TestEnvironment_Player->play() /Users/agnieszka/qa-stories-v2/vendor/datasift/storyplayer/src/php/DataSift/Storyplayer/Cli/PlayStory/Command.php:269
PHP   9. DataSift\Storyplayer\PlayerLib\Story_Player->play() /Users/agnieszka/qa-stories-v2/vendor/datasift/storyplayer/src/php/DataSift/Storyplayer/PlayerLib/TestEnvironment/Player.php:111
PHP  10. DataSift\Storyplayer\PlayerLib\StoryTeller->setStory() /Users/agnieszka/qa-stories-v2/vendor/datasift/storyplayer/src/php/DataSift/Storyplayer/PlayerLib/Story/Player.php:108