### PR TITLE
Fixed error caused by unsetting items whilst iterating through foreach list

### DIFF
--- a/src/php/Prose/UsingRuntimeTableForTargetEnvironment.php
+++ b/src/php/Prose/UsingRuntimeTableForTargetEnvironment.php
@@ -301,7 +301,9 @@ class UsingRuntimeTableForTargetEnvironment extends BaseRuntimeTable
             return;
         }
 
-        foreach ($tables->$tableName->$targetEnv as $groupName => $group) {
+        $groupNames = (array_keys($groups));
+        foreach ($groupNames as $groupName) {
+            $group = $tables->$tableName->$targetEnv->$groupName;
             if (isset($group->$key)) {
                 // remove the entry
                 unset($group->$key);


### PR DESCRIPTION
This fixes a "segmentation fault 11" error that manifests itself during the test destruction phase with tests with a lot of roles.